### PR TITLE
Datetime filter for disbursement service

### DIFF
--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -1,4 +1,5 @@
 class Disbursement < ApplicationRecord
   belongs_to :order
   validates_presence_of :fee_amount, :final_amount
+  validates_uniqueness_of :order_id
 end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -1,5 +1,4 @@
 class Disbursement < ApplicationRecord
   belongs_to :order
   validates_presence_of :fee_amount, :final_amount
-  validates_uniqueness_of :order_id
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,4 +3,8 @@ class Order < ApplicationRecord
   belongs_to :merchant
   has_one :disbursement
   validates_presence_of :amount
+
+  def disbursement_completed?
+    !disbursement.nil?
+  end
 end

--- a/app/services/disbursements/create_service.rb
+++ b/app/services/disbursements/create_service.rb
@@ -1,6 +1,11 @@
 module Disbursements
   class CreateService < ApplicationService
     include Dry::Monads[:result, :maybe]
+    attr_reader :start_datetime, :end_datetime
+    def initialize(start_datetime=nil, end_datetime=nil)
+      @start_datetime = start_datetime || Time.now.last_week.beginning_of_week
+      @end_datetime = end_datetime || Time.now.last_week.end_of_week
+    end
 
     def perform
       completed_orders.bind do |orders|
@@ -16,11 +21,13 @@ module Disbursements
       disbursements = []
       Disbursement.transaction do
         orders.each do |order|
+          next if order.disbursement_completed?
+
           fee_slab = Maybe(FeeSlab.compute_range(val: order.amount)).value_or(FEE_SLAB_NOT_FOUND)
           raise FeeSlabError::FeeSlabNotFound.new("order Id: #{order.id}") if fee_slab == FEE_SLAB_NOT_FOUND
-
           fee_amount = ::Currency.multiple(order.amount, fee_slab)
           final_amount = ::Currency.add(order.amount, fee_amount)
+
           disbursement = Disbursement.new(
             order: order,
             fee_amount: fee_amount,
@@ -41,10 +48,8 @@ module Disbursements
     end
 
     def completed_orders
-      start_of_previous_week = Time.now.last_week.beginning_of_week
-      end_of_previous_week = Time.now.last_week.end_of_week
       completed_orders = Order.where(
-        completed_at: [start_of_previous_week..end_of_previous_week]
+        completed_at: [start_datetime..end_datetime]
       )
       if completed_orders.empty?
         Failure("No orders found that are completed")

--- a/app/services/disbursements/create_service.rb
+++ b/app/services/disbursements/create_service.rb
@@ -2,6 +2,7 @@ module Disbursements
   class CreateService < ApplicationService
     include Dry::Monads[:result, :maybe]
     attr_reader :start_datetime, :end_datetime
+
     def initialize(start_datetime=nil, end_datetime=nil)
       @start_datetime = start_datetime || Time.now.last_week.beginning_of_week
       @end_datetime = end_datetime || Time.now.last_week.end_of_week

--- a/lib/currency.rb
+++ b/lib/currency.rb
@@ -1,6 +1,6 @@
 class Currency
   class << self
-    def multiple(* args, precision: 2)
+    def multiple(*args, precision: 2)
       args.map { |val| BigDecimal(val) }.reduce(&:*).round(precision)
     end
 

--- a/lib/tasks/load_test_data.rake
+++ b/lib/tasks/load_test_data.rake
@@ -32,7 +32,7 @@ task :load_test_data => :environment do
       merchant_id: order["merchant_id"],
       shopper_id: order["shopper_id"],
       amount: order["amount"],
-      completed_at: order["completed_at"]
+      completed_at: Time.now.last_week.beginning_of_week + Random.random_number(7)
     )
   end
 

--- a/test/services/disbursements/create_service_test.rb
+++ b/test/services/disbursements/create_service_test.rb
@@ -7,7 +7,7 @@ module Disbursements
         merchant: merchants(:treutel),
         shopper: shoppers(:olive),
         amount: 230,
-        completed_at: Time.now.last_week.beginning_of_week + 1
+        completed_at: Time.now.last_week.beginning_of_week + 1.day
       )
       result = Disbursements::CreateService.perform
       disbursement = Disbursement.find_by(order_id: order.id)
@@ -58,7 +58,7 @@ module Disbursements
         merchant: merchants(:treutel),
         shopper: shoppers(:olive),
         amount: -1,
-        completed_at: Time.now.last_week.beginning_of_week + 1
+        completed_at: Time.now.last_week.beginning_of_week + 1.day
       )
       result = Disbursements::CreateService.perform
       assert result.failure?
@@ -71,12 +71,32 @@ module Disbursements
       Order.create!(
         merchant: merchants(:treutel),
         shopper: shoppers(:olive),
+        amount: 200,
+        completed_at: Time.now.last_week.beginning_of_week + 1.day
+      )
+      Order.create!(
+        merchant: merchants(:treutel),
+        shopper: shoppers(:olive),
         amount: -1,
-        completed_at: Time.now.last_week.beginning_of_week + 1
+        completed_at: Time.now.last_week.beginning_of_week + 1.day
       )
       result = Disbursements::CreateService.perform
       assert result.failure?
       assert Disbursement.all.empty?
+    end
+
+    test "exclude if its already processed for week" do
+      Order.create!(
+        merchant: merchants(:treutel),
+        shopper: shoppers(:olive),
+        amount: 200,
+        completed_at: Time.now.last_week.beginning_of_week + 1.day
+      )
+      Disbursements::CreateService.perform
+      result = Disbursements::CreateService.perform
+
+      assert result.success?
+      assert result.value!.empty?
     end
   end
 end


### PR DESCRIPTION
Previous to this, there was no filter to service. It was fetching the start date and end date based on the Current date's previous week. This is great but, doesn't give enough flexibility for running the job for an extended time. 

Also, added a condition not to run for orders that have already processed disbursement.