### PR TITLE
Disbursement API

### DIFF
--- a/app/controllers/api/disbursements_controller.rb
+++ b/app/controllers/api/disbursements_controller.rb
@@ -1,0 +1,30 @@
+module Api
+  class DisbursementsController < ApplicationController
+    before_action :validate_query_params, only: [:index]
+
+    def index
+      start_date_of_week = Time.parse(params[:start_date_of_week]).beginning_of_week
+      end_date_of_week = start_date_of_week.end_of_week
+
+      # Extract to query objects in future.
+      disbursements = Disbursement
+                        .joins_merchant_shopper
+                        .by_start_end_date_time(start_date_of_week, end_date_of_week)
+                        .by_merchant_id(params[:merchant_id])
+                        .select("disbursements.id", "disbursements.order_id",
+                                "disbursements.final_amount", "disbursements.fee_amount",
+                                "merchants.name as merchant_name", "shoppers.name as shopper_name")
+      render json: disbursements, status: :ok
+    end
+
+    private
+
+    def validate_query_params
+      # Extract to filters and make extensible concern.
+
+      if !params.has_key? :start_date_of_week
+        render json: { message: "start_date_of_week is missing"}, status: :bad_request
+      end
+    end
+  end
+end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -1,4 +1,17 @@
 class Disbursement < ApplicationRecord
   belongs_to :order
   validates_presence_of :fee_amount, :final_amount
+
+  scope :joins_merchant_shopper, -> {
+    joins(order: [:merchant, :shopper])
+  }
+
+  scope :by_start_end_date_time, -> (start_date_of_week, end_date_of_week) {
+    where(created_at: [start_date_of_week..end_date_of_week])
+  }
+
+  scope :by_merchant_id, -> (merchant_id) {
+    # Always use in conjunction with joins_merchant_shopper scope
+    where(orders: {merchant_id: merchant_id}) if merchant_id.present?
+  }
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,4 +1,5 @@
 class Merchant < ApplicationRecord
   has_many :orders
+  has_many :shoppers, through: :orders
   validates_presence_of :email, :name
 end

--- a/app/models/shopper.rb
+++ b/app/models/shopper.rb
@@ -1,4 +1,5 @@
 class Shopper < ApplicationRecord
   has_many :orders
+  has_many :merchants, through: :orders
   validates_presence_of :email, :name, :nif
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    resources :disbursements, only: [:index]
+  end
 end

--- a/test/controllers/disbursements_controller_test.rb
+++ b/test/controllers/disbursements_controller_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class DisbursementControllerTest < ActionDispatch::IntegrationTest
+  test "query parms with start date of week and merchant Id" do
+    merchant = merchants(:treutel)
+    order = Order.create!(
+      merchant: merchant,
+      shopper: shoppers(:olive),
+      amount: 200,
+      completed_at: Time.now.last_week.beginning_of_week + 1.day
+    )
+    Disbursements::CreateService.perform
+    get api_disbursements_path, params: {
+      start_date_of_week: Date.today.to_s,
+      merchant: merchant.id
+    }
+    disbursement = JSON.parse(response.body).first
+    assert_response :success
+    assert_equal 1.9, disbursement["fee_amount"].to_d
+    assert_equal 201.9, disbursement["final_amount"].to_d
+    assert_equal merchant.name, disbursement["merchant_name"]
+    assert_equal order.shopper.name, disbursement["shopper_name"]
+  end
+
+  test "returns all merchants without merchant Id in query params" do
+    Order.create!(
+      merchant: merchants(:treutel),
+      shopper: shoppers(:olive),
+      amount: 200,
+      completed_at: Time.now.last_week.beginning_of_week + 1.day
+    )
+    Order.create!(
+      merchant: merchants(:schoen),
+      shopper: shoppers(:olive),
+      amount: 200,
+      completed_at: Time.now.last_week.beginning_of_week + 1.day
+    )
+    Disbursements::CreateService.perform
+    get api_disbursements_path, params: {
+      start_date_of_week: Date.today.to_s
+    }
+    disbursements = JSON.parse(response.body)
+    assert_response :success
+    assert_equal 2, disbursements.count
+    assert_equal ["Schoen Inc", "Treutel, Schumm and Fadel"], disbursements.pluck("merchant_name").sort
+  end
+
+  test "start date of week is missing" do
+    Order.create!(
+      merchant: merchants(:treutel),
+      shopper: shoppers(:olive),
+      amount: 200,
+      completed_at: Time.now.last_week.beginning_of_week + 1.day
+    )
+    Disbursements::CreateService.perform
+    get api_disbursements_path, params: {
+      merchant_id: merchants(:treutel).id
+    }
+    assert_response :bad_request
+    assert_equal "start_date_of_week is missing", JSON.parse(response.body)["message"]
+  end
+
+  test "returns empty if no disbursements for start date week" do
+    Order.create!(
+      merchant: merchants(:treutel),
+      shopper: shoppers(:olive),
+      amount: 200,
+      completed_at: Time.now.last_week.beginning_of_week + 1.day
+    )
+    Disbursements::CreateService.perform
+    get api_disbursements_path, params: {
+      start_date_of_week: (Date.today - 10.days).to_s
+    }
+    assert_response :success
+    assert JSON.parse(response.body).empty?
+  end
+end

--- a/test/fixtures/merchants.yml
+++ b/test/fixtures/merchants.yml
@@ -3,10 +3,13 @@
 # This model initially had no columns defined. If you add columns to the
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
-#
 
 treutel:
   name: "Treutel, Schumm and Fadel"
   email: "info@treutel-schumm-and-fadel.com"
   cif: "B611111111"
 
+schoen:
+  name: "Schoen Inc"
+  email: "info@schoen-inc.com"
+  cif: "B611111110"


### PR DESCRIPTION
**(3/3)** - Create an API endpoint to expose the disbursements for a given merchant on a given week. If no merchant is provided return for all of them.

The start date of the week essentially takes care of pulling the date range of values.

- [x]  Setup query parameters that will be able to pull the values based on merchant ID and the start date of the week.
- [x]  If the merchant ID is not passed in query parameters, return all merchants.
- [x]  Setup scopes for joins to improve performance when pulling larger values in selects.


